### PR TITLE
Use agility stat for fleeing

### DIFF
--- a/docs/GAME_GUIDE.md
+++ b/docs/GAME_GUIDE.md
@@ -35,7 +35,7 @@ LOGDTW2002 is a text-based adventure game that combines the RPG elements of Lege
 
 - **Level System**: Gain experience through combat, quests, and exploration
 - **Skills**: Improve combat, pilot, trading, engineering, navigation, and diplomacy
-- **Stats**: Strength, Dexterity, Constitution, Intelligence, Wisdom, Charisma
+- **Stats**: Strength, Agility, Endurance, Intelligence, Charisma, Perception
 - **Equipment**: Weapons, armor, shields, and special items
 
 ### Space Exploration

--- a/game/combat.py
+++ b/game/combat.py
@@ -184,8 +184,8 @@ class CombatSystem:
         if not self.in_combat:
             return {'success': False, 'message': 'Not in combat'}
         
-        # Fleeing chance based on player dexterity
-        flee_chance = min(0.8, self.player.stats['dexterity'] / 20)
+        # Fleeing chance based on player agility
+        flee_chance = min(0.8, self.player.stats['agility'] / 20)
         
         if random.random() < flee_chance:
             result = {


### PR DESCRIPTION
## Summary
- Base flee chance on player's agility instead of nonexistent dexterity
- Update game guide to list current player stats

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_68971039e59083278d93d708837ccbd4