### PR TITLE
Add system documentation for market, saves, missions, and AI counselor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ A text-based adventure game that combines the RPG elements of Legend of the Gree
 - `data/` - Game data files
 - `utils/` - Utility functions and helpers
 
+## Documentation
+
+- [Dynamic Market System](docs/dynamic_market.md)
+- [Save System](docs/save_system.md)
+- [Mission Generator](docs/mission_generator.md)
+- [AI Counselor](docs/ai_counselor.md)
+
 ## Contributing
 
 Feel free to contribute by adding new features, fixing bugs, or improving the game mechanics!

--- a/docs/ai_counselor.md
+++ b/docs/ai_counselor.md
@@ -1,0 +1,35 @@
+# AI Counselor
+
+## Purpose
+A cheeky onboard AI that offers sarcastic yet helpful advice through a chat interface, enriching player interactions and providing hints.
+
+## Key Classes
+- `CounselorResponse` – dataclass holding the generated message, mood and optional context.
+- `ShipCounselor` – main chatbot class; parses player input, selects responses and displays them with the `rich` console library.
+
+## Integration Points
+- Can be invoked from any game screen to provide feedback based on current player context (credits, health, fuel, etc.).
+- Conversations and advice can be recorded as part of the player's game state for persistence via the `SaveGameSystem`.
+
+## Example Usage
+```python
+from game.ai_counselor import ShipCounselor
+
+counselor = ShipCounselor()
+response = counselor.chat("I need help with trading", player_context={"credits": 50})
+counselor.display_response(response)
+```
+
+## Chat Flow
+```mermaid
+graph TD
+    A[Player Input] --> B[Analyze Text]
+    B --> C{Context Keywords?}
+    C -->|Greeting/Farewell| D[Stock Response]
+    C -->|Help Topic| E[Helpful Advice]
+    C -->|None| F[General/Sarcastic Reply]
+    D --> G[Display]
+    E --> G
+    F --> G
+```
+

--- a/docs/dynamic_market.md
+++ b/docs/dynamic_market.md
@@ -1,0 +1,53 @@
+# Dynamic Market System
+
+## Purpose
+Provides a living economy where commodity prices shift with supply and demand, seasonal trends and random galactic events.  Each sector maintains its own economy so trading routes feel reactive and dynamic.
+
+## Key Classes
+- `MarketCondition` – overall health of a sector's economy.
+- `EconomicEvent` – large scale events such as wars or shortages that modify prices.
+- `CommodityCategory` – grouping for goods (food, minerals, technology, etc.).
+- `MarketData` – per‑commodity information including price, supply and volatility.
+- `SectorEconomy` – economic profile for a sector including imports/exports and trade routes.
+- `DynamicMarketSystem` – orchestrates price updates, economic events and trade execution.
+
+## Integration Points
+- Used by the `TradingSystem` to price goods and determine profitable routes.
+- Sector data from the world/sector generator feeds into `initialize_sector_economy`.
+- Market state can be persisted through the `SaveGameSystem` by storing `trading_data`.
+
+## Example Usage
+```python
+from game.dynamic_markets import DynamicMarketSystem
+
+market = DynamicMarketSystem()
+market.initialize_sector_economy(
+    sector_id=1,
+    wealth_level=1.0,
+    population=500_000,
+    industrial_capacity=1.2,
+    trade_routes=[2, 3]
+)
+
+# advance the simulation
+market.update_market(turn_number=1)
+prices = market.get_sector_prices(1)
+print(prices.get("Gold"))
+
+# execute a trade
+trade = market.execute_trade("Gold", quantity=10, sector_id=1, is_buy=True)
+print(trade)
+```
+
+## Flow
+```mermaid
+graph TD
+    A[Start Turn] --> B[Update Commodity Prices]
+    B --> C{Trigger Economic Event?}
+    C -->|Yes| D[Apply Event Modifiers]
+    C -->|No| E[Seasonal Trends]
+    D --> F[Update Sector Economies]
+    E --> F
+    F --> G[Record History]
+```
+

--- a/docs/mission_generator.md
+++ b/docs/mission_generator.md
@@ -1,0 +1,46 @@
+# Mission Generator
+
+## Purpose
+Creates both procedural and story driven missions with dynamic objectives, difficulty scaling and branching chains.  It keeps the game world populated with tasks appropriate to the player's progress.
+
+## Key Classes
+- `MissionType`, `MissionDifficulty`, `MissionStatus`, `ObjectiveType` – enums that define mission properties.
+- `MissionObjective` – single task within a mission (kill, collect, deliver, etc.).
+- `MissionReward` – credits, items and reputation awarded on completion.
+- `Mission` – complete mission definition with objectives and rewards.
+- `MissionChain` – ordered or branching sequences of missions forming a storyline.
+- `MissionGenerator` – builds procedural missions from templates and player context.
+- `StoryMissionManager` – manages predefined story chains.
+- `MissionManager` – top‑level system tracking active/available missions and updating progress each turn.
+
+## Integration Points
+- The mission manager can query player level, location and reputation from `Player` and world modules.
+- Completed missions award rewards and can influence the trading or dynamic market systems.
+- Mission state is stored via `SaveGameSystem` inside the `mission_data` portion of `GameState`.
+
+## Example Usage
+```python
+from game.enhanced_missions import MissionManager
+
+missions = MissionManager()
+missions.update_turn()               # generate initial missions
+available = missions.get_available_missions(player_level=5,
+                                            player_location=1,
+                                            player_progress={})
+chosen = available[0]
+missions.accept_mission(chosen.id)
+
+# progress an objective
+missions.update_mission_progress(chosen.id, chosen.objectives[0].id, amount=1)
+```
+
+## Mission Flow
+```mermaid
+graph TD
+    A[Generate/Receive Mission] --> B[Accept Mission]
+    B --> C[Track Objectives]
+    C --> D{All Objectives Complete?}
+    D -->|No| B
+    D -->|Yes| E[Grant Rewards & Update Story]
+```
+

--- a/docs/save_system.md
+++ b/docs/save_system.md
@@ -1,0 +1,43 @@
+# Save System
+
+## Purpose
+Handles persistent game progress with compression, checksums, auto‑saving and backup management.  Game sessions can be restored exactly as they were left.
+
+## Key Classes
+- `SaveMetadata` – summary information for each save slot.
+- `GameState` – serialisable snapshot of player, world and mission data.
+- `SaveGameSystem` – core manager providing `save_game`, `load_game`, `auto_save`, backups and integrity checks.
+
+## Integration Points
+- `SaveGameSystem.create_game_state` gathers data from player, world, missions, NPCs and trading systems.
+- Auto‑save can be triggered from the main loop or combat/travel subsystems.
+- Market and mission modules persist their state by storing into the `trading_data` and `mission_data` fields of `GameState`.
+
+## Example Usage
+```python
+from game.save_system import SaveGameSystem, GameState
+
+save_system = SaveGameSystem()
+
+state = GameState(
+    player_data={"name": "Nova", "level": 3, "credits": 1200},
+    world_data={"current_sector": 1},
+    mission_data={}, npc_data={}, trading_data={},
+    skill_data={}, combat_data={}, settings={}, statistics={},
+    achievements=[], timestamp=0.0
+)
+
+save_id = save_system.save_game(state, description="Before battle")
+loaded_state = save_system.load_game(save_id)
+```
+
+## Save Flow
+```mermaid
+graph TD
+    A[Create GameState] --> B[Serialize with pickle]
+    B --> C[Compress & Checksum]
+    C --> D[Write .sav file]
+    D --> E[Update metadata.json]
+    E --> F[Optional Backup]
+```
+


### PR DESCRIPTION
## Summary
- Document dynamic market system, save system, mission generator, and AI counselor
- Link new docs from README

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'game')*


------
https://chatgpt.com/codex/tasks/task_e_68971059a5c883278a4c947bc24e8c59