### PR TITLE
Add deterministic tests for markets and save system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 colorama==0.4.6
 pyfiglet==1.0.2
 rich==13.7.0
+pytest==8.2.0

--- a/tests/test_dynamic_market.py
+++ b/tests/test_dynamic_market.py
@@ -1,0 +1,40 @@
+import random
+import pytest
+
+from game.dynamic_markets import DynamicMarketSystem
+from game.player import Player
+from game.world import World
+
+
+@pytest.fixture
+def player():
+    return Player()
+
+
+@pytest.fixture
+def world():
+    return World()
+
+
+def test_price_update(player, world):
+    random.seed(0)
+    market = DynamicMarketSystem()
+    initial_price = market.commodities["Food"].current_price
+    market.update_market(1)
+    updated_price = market.commodities["Food"].current_price
+    assert updated_price == pytest.approx(48.3424665093561)
+    assert updated_price != initial_price
+
+
+def test_event_effect(player, world):
+    random.seed(0)
+    market = DynamicMarketSystem()
+    initial_price = market.commodities["AI Cores"].current_price
+    random.seed(0)
+    market._trigger_random_event()
+    assert market.commodities["AI Cores"].event_modifier == pytest.approx(0.6)
+    market.update_market(1)
+    updated_price = market.commodities["AI Cores"].current_price
+    assert updated_price == pytest.approx(10587.776386834694)
+    assert updated_price < initial_price
+

--- a/tests/test_save_system.py
+++ b/tests/test_save_system.py
@@ -1,0 +1,43 @@
+import random
+import pytest
+
+from game.save_system import SaveGameSystem, GameState
+from game.player import Player
+from game.world import World
+
+
+@pytest.fixture
+def player():
+    return Player()
+
+
+@pytest.fixture
+def world():
+    return World()
+
+
+def test_save_load_round_trip(tmp_path, player, world):
+    random.seed(0)
+    save_system = SaveGameSystem(save_directory=str(tmp_path))
+    state = GameState(
+        player_data={
+            'name': player.name,
+            'ship_name': player.ship_name,
+            'level': player.level,
+            'credits': player.credits
+        },
+        world_data={'current_sector': world.current_sector},
+        mission_data={},
+        npc_data={},
+        trading_data={},
+        skill_data={},
+        combat_data={},
+        settings={},
+        statistics={'play_time': 0},
+        achievements=[],
+        timestamp=0.0
+    )
+    save_id = save_system.save_game(state, save_name='test_save', overwrite=True)
+    loaded = save_system.load_game(save_id)
+    assert loaded == state
+

--- a/tests/test_stock_market.py
+++ b/tests/test_stock_market.py
@@ -1,0 +1,28 @@
+import random
+import pytest
+
+from game.stock_market import StockMarket
+from game.player import Player
+from game.world import World
+
+
+@pytest.fixture
+def player():
+    return Player()
+
+
+@pytest.fixture
+def world():
+    return World()
+
+
+def test_stock_price_update(player, world):
+    random.seed(0)
+    market = StockMarket()
+    market.last_update -= 1000
+    initial_price = market.stocks['TECH'].current_price
+    market.update_market()
+    updated_price = market.stocks['TECH'].current_price
+    assert updated_price == pytest.approx(161.30058485616797)
+    assert updated_price != initial_price
+


### PR DESCRIPTION
## Summary
- add dynamic market tests verifying price updates and event impacts with seeded randomness
- check stock market price updates deterministically
- ensure save/load round trip works using SaveGameSystem
- include pytest in requirements

## Testing
- `PYTHONPATH=. pytest tests/test_dynamic_market.py tests/test_stock_market.py tests/test_save_system.py`

------
https://chatgpt.com/codex/tasks/task_e_6897105729488327a5a0b0341e1915a3