### PR TITLE
Add mental health stat and holodeck reward handling

### DIFF
--- a/game/holodeck.py
+++ b/game/holodeck.py
@@ -220,7 +220,7 @@ class HolodeckSystem:
                     player.skills['survival'].gain_experience(amount)
                 rewards_given.append(f"+{amount} Survival")
             elif reward_type == 'mental_health':
-                # Mental health affects stress levels
+                player.add_mental_health(amount)
                 rewards_given.append(f"+{amount} Mental Health")
             elif reward_type == 'piloting':
                 if 'piloting' in player.skills:

--- a/game/player.py
+++ b/game/player.py
@@ -46,6 +46,8 @@ class Player:
         self.max_health = 100
         self.energy = 100
         self.max_energy = 100
+        self.mental_health = 100
+        self.max_mental_health = 100
         self.fuel = 100
         self.max_fuel = 100
         
@@ -303,7 +305,18 @@ class Player:
             self.energy -= amount
             return True
         return False
-    
+
+    def add_mental_health(self, amount: int):
+        """Add mental health to player"""
+        self.mental_health = min(self.max_mental_health, self.mental_health + amount)
+
+    def use_mental_health(self, amount: int) -> bool:
+        """Use mental health"""
+        if self.mental_health >= amount:
+            self.mental_health -= amount
+            return True
+        return False
+
     def add_fuel(self, amount: int):
         """Add fuel to player"""
         self.fuel = min(self.max_fuel, self.fuel + amount)


### PR DESCRIPTION
## Summary
- Add mental health resource with helper methods to Player
- Update holodeck completion to restore mental health when rewarded

## Testing
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'World' object has no attribute 'can_jump_to')*

------
https://chatgpt.com/codex/tasks/task_e_6897104a04148327b33f63866f0a2043