### PR TITLE
Add diplomacy system with treaties and player integration

### DIFF
--- a/game/diplomacy.py
+++ b/game/diplomacy.py
@@ -1,0 +1,67 @@
+"""Diplomacy system for managing faction relationships and treaties."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    """Clamp ``value`` between ``minimum`` and ``maximum``."""
+    return max(minimum, min(maximum, value))
+
+
+@dataclass
+class Diplomacy:
+    """Maintain faction standings and treaties.
+
+    The system keeps track of how the player is viewed by various factions and
+    manages simple treaties with consequences when relationships sour.
+    """
+
+    factions: Optional[List[str]] = None
+    standings: Dict[str, int] = field(default_factory=dict)
+    treaties: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.factions:
+            for faction in self.factions:
+                self.standings.setdefault(faction, 0)
+
+    # -- standings ---------------------------------------------------------
+    def change_standing(self, faction: str, amount: int) -> int:
+        """Adjust reputation with ``faction`` by ``amount``.
+
+        Returns the new standing after applying the change. Standings are kept
+        within the -100 to 100 range. If a standing drops below -50, any treaty
+        with that faction is automatically broken as a consequence.
+        """
+        current = self.standings.get(faction, 0)
+        new_value = _clamp(current + amount, -100, 100)
+        self.standings[faction] = new_value
+        self._evaluate_consequences(faction)
+        return new_value
+
+    # -- treaties ----------------------------------------------------------
+    def form_treaty(self, faction: str, treaty_type: str) -> None:
+        """Establish a ``treaty_type`` with ``faction``."""
+        self.treaties[faction] = treaty_type
+
+    def break_treaty(self, faction: str) -> None:
+        """Terminate any existing treaty with ``faction``."""
+        self.treaties.pop(faction, None)
+
+    def has_treaty(self, faction: str, treaty_type: Optional[str] = None) -> bool:
+        """Return ``True`` if a treaty exists with ``faction``.
+
+        If ``treaty_type`` is provided, the treaty must match that type.
+        """
+        current = self.treaties.get(faction)
+        if treaty_type is None:
+            return current is not None
+        return current == treaty_type
+
+    # -- internal helpers --------------------------------------------------
+    def _evaluate_consequences(self, faction: str) -> None:
+        """Handle consequences of the current standing with ``faction``."""
+        if self.standings.get(faction, 0) < -50 and faction in self.treaties:
+            self.break_treaty(faction)

--- a/game/player.py
+++ b/game/player.py
@@ -7,6 +7,7 @@ import random
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from game.skills import Skill
+from game.diplomacy import Diplomacy
 
 @dataclass
 class Item:
@@ -109,6 +110,9 @@ class Player:
             'Traders': 0,
             'Neutral': 0
         }
+
+        # Diplomacy system handles standings and treaties
+        self.diplomacy = Diplomacy(list(self.reputation.keys()))
         
         # Coordinates
         self.coordinates = (0, 0, 0)
@@ -414,11 +418,36 @@ class Player:
     def get_inventory_value(self) -> int:
         """Calculate total value of inventory"""
         return sum(item.value for item in self.inventory)
-    
+
     def get_equipment_value(self) -> int:
         """Calculate total value of equipped items"""
         return sum(item.value for item in self.equipped.values() if item)
-    
+
     def get_total_wealth(self) -> int:
         """Calculate total wealth (credits + inventory + equipment)"""
         return self.credits + self.get_inventory_value() + self.get_equipment_value()
+
+    # -- Diplomacy interactions -----------------------------------------
+    def improve_relationship(self, faction: str, amount: int) -> int:
+        """Improve standing with a faction and return the new value."""
+        new_rep = self.diplomacy.change_standing(faction, abs(amount))
+        self.reputation[faction] = new_rep
+        return new_rep
+
+    def ruin_relationship(self, faction: str, amount: int) -> int:
+        """Decrease standing with a faction and return the new value."""
+        new_rep = self.diplomacy.change_standing(faction, -abs(amount))
+        self.reputation[faction] = new_rep
+        return new_rep
+
+    def form_treaty(self, faction: str, treaty_type: str) -> None:
+        """Form a treaty with a faction."""
+        self.diplomacy.form_treaty(faction, treaty_type)
+
+    def break_treaty(self, faction: str) -> None:
+        """Break an existing treaty with a faction."""
+        self.diplomacy.break_treaty(faction)
+
+    def has_treaty(self, faction: str, treaty_type: Optional[str] = None) -> bool:
+        """Check if a treaty exists with a faction."""
+        return self.diplomacy.has_treaty(faction, treaty_type)

--- a/tests/test_diplomacy.py
+++ b/tests/test_diplomacy.py
@@ -1,0 +1,25 @@
+import pytest
+
+from game.player import Player
+
+
+def test_reputation_changes():
+    player = Player()
+    start = player.reputation["Federation"]
+
+    player.improve_relationship("Federation", 20)
+    assert player.reputation["Federation"] == start + 20
+
+    player.ruin_relationship("Federation", 40)
+    assert player.reputation["Federation"] == start - 20
+
+
+def test_treaty_breaks_on_negative_reputation():
+    player = Player()
+    player.form_treaty("Pirates", "non-aggression")
+    assert player.has_treaty("Pirates", "non-aggression")
+
+    # Drop reputation below -50 which should break the treaty automatically
+    player.ruin_relationship("Pirates", 60)
+    assert player.reputation["Pirates"] == -60
+    assert not player.has_treaty("Pirates")


### PR DESCRIPTION
## Summary
- implement Diplomacy class to manage faction standings, treaties, and consequences
- wire Player into new diplomacy API with helpers for reputation and treaties
- add tests covering reputation changes and treaty breakdown on hostile relations

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689711c79200832796c7f523d0c29d8b