### PR TITLE
Add basic crafting system

### DIFF
--- a/game/crafting.py
+++ b/game/crafting.py
@@ -1,0 +1,42 @@
+"""Crafting system with recipes and crafting API."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, Any
+
+from game.player import Item, Player
+
+# Basic recipe definitions. Keys are recipe names, values contain required
+# materials and the resulting item template. The result is deep copied when
+# crafting to avoid shared state between items.
+RECIPES: Dict[str, Dict[str, Any]] = {
+    "health_potion": {
+        "materials": {"herb": 2, "water": 1},
+        "result": Item("Health Potion", "Restores health", 10, "consumable"),
+    }
+}
+
+
+def craft_item(player: Player, recipe: Dict[str, Any]) -> Dict[str, Any]:
+    """Attempt to craft an item for the given player.
+
+    Args:
+        player: The player performing the crafting.
+        recipe: Recipe dictionary containing ``materials`` and ``result``.
+
+    Returns:
+        Dictionary with ``success`` flag and additional info/message.
+    """
+    required = recipe.get("materials", {})
+
+    if not player.has_materials(required):
+        return {"success": False, "message": "Missing materials"}
+
+    if len(player.inventory) >= player.max_inventory:
+        return {"success": False, "message": "Inventory full"}
+
+    # Remove materials and add crafted item
+    player.remove_materials(required)
+    crafted = deepcopy(recipe["result"])
+    player.add_item(crafted)
+    return {"success": True, "item": crafted}

--- a/game/player.py
+++ b/game/player.py
@@ -86,6 +86,9 @@ class Player:
         # Inventory
         self.inventory = []
         self.max_inventory = 20
+
+        # Crafting materials
+        self.materials: Dict[str, int] = {}
         
         # Ship information
         self.ship = {
@@ -195,9 +198,35 @@ class Player:
         """Add item to inventory"""
         if len(self.inventory) >= self.max_inventory:
             return False
-        
+
         self.inventory.append(item)
         return True
+
+    def add_material(self, material: str, quantity: int = 1):
+        """Add crafting materials to the player's stock."""
+        self.materials[material] = self.materials.get(material, 0) + quantity
+
+    def has_materials(self, required: Dict[str, int]) -> bool:
+        """Check if the player has the required crafting materials."""
+        return all(self.materials.get(mat, 0) >= qty for mat, qty in required.items())
+
+    def remove_materials(self, required: Dict[str, int]):
+        """Remove crafting materials after crafting."""
+        for mat, qty in required.items():
+            if mat in self.materials:
+                self.materials[mat] -= qty
+                if self.materials[mat] <= 0:
+                    del self.materials[mat]
+
+    def craft(self, recipe_name: str):
+        """Craft an item using a known recipe."""
+        from game.crafting import RECIPES, craft_item
+
+        recipe = RECIPES.get(recipe_name)
+        if not recipe:
+            return {"success": False, "message": "Unknown recipe"}
+
+        return craft_item(self, recipe)
     
     def remove_item(self, item_name: str, quantity: int = 1) -> Optional[Item]:
         """Remove item from inventory by name and quantity"""

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+# Ensure project root on path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from game.player import Player, Item
+from game.crafting import RECIPES
+
+def test_successful_crafting():
+    player = Player()
+    player.add_material('herb', 2)
+    player.add_material('water', 1)
+    prev_len = len(player.inventory)
+
+    result = player.craft('health_potion')
+
+    assert result['success']
+    assert len(player.inventory) == prev_len + 1
+    assert all(player.materials.get(mat, 0) == 0 for mat in ['herb', 'water'])
+
+
+def test_missing_materials():
+    player = Player()
+    player.add_material('herb', 1)  # Not enough
+    result = player.craft('health_potion')
+    assert not result['success']
+    assert 'Missing materials' in result['message']
+
+
+def test_inventory_overflow():
+    player = Player()
+    player.add_material('herb', 2)
+    player.add_material('water', 1)
+
+    # Fill inventory
+    while len(player.inventory) < player.max_inventory:
+        player.add_item(Item('Junk', 'junk', 1, 'equipment'))
+
+    materials_before = dict(player.materials)
+    result = player.craft('health_potion')
+    assert not result['success']
+    assert 'Inventory full' in result['message']
+    # Materials should remain
+    assert player.materials == materials_before


### PR DESCRIPTION
## Summary
- add `game.crafting` with recipe definitions and `craft_item` API
- extend `Player` to track materials and craft items
- create tests for crafting flow, missing materials, and full inventory

## Testing
- `pytest tests/test_crafting.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'game')*


------
https://chatgpt.com/codex/tasks/task_e_689711c6d0088327bb5afdd32dd217aa