### PR TITLE
Integrate dynamic mission generation into quest system

### DIFF
--- a/main.py
+++ b/main.py
@@ -401,6 +401,7 @@ sectors - All sectors  sector - Current sector
                     self.handle_combat(command)
                 
                 elif command.lower() in ['quests', 'missions']:
+                    self.quest_system.generate_dynamic_quest(self.player)
                     self.display.show_quests(self.quest_system.get_available_quests(self.player))
                 
                 elif command.lower() in ['genesis', 'fire genesis']:


### PR DESCRIPTION
## Summary
- Import `MissionGenerator` and add dynamic quest conversion in `QuestSystem`
- Track branching data on quest completion and failure
- Generate procedural missions when viewing the quest list

## Testing
- `PYTHONPATH=. pytest` *(fails: assert 7 == 6; AttributeError: 'World' object has no attribute 'can_jump_to')*

------
https://chatgpt.com/codex/tasks/task_e_68971053739083278653804d3a6a369a