### PR TITLE
Add event engine and integrate with travel, missions, and markets

### DIFF
--- a/game/dynamic_markets.py
+++ b/game/dynamic_markets.py
@@ -445,6 +445,53 @@ class DynamicMarketSystem:
         
         self.active_events.append(event)
         print(f"🌟 Economic Event: {event.description}")
+
+    def trigger_event(self, event_type: EconomicEvent):
+        """Trigger a specific economic event.
+
+        The dynamic market system already supports random events internally.
+        This public method exposes the same functionality for external systems
+        such as the :class:`EventEngine` so that other gameplay systems can
+        cause market-wide disturbances.
+        """
+        if event_type == EconomicEvent.NONE:
+            return None
+
+        template = self.economic_event_templates.get(event_type)
+        if not template:
+            return None
+
+        duration = random.randint(*template["duration"])
+        event = EconomicEventData(
+            event_type=event_type,
+            affected_commodities=template["affected_commodities"],
+            price_modifiers=template["price_modifiers"],
+            supply_modifiers=template.get("supply_modifiers", {}),
+            demand_modifiers=template.get("demand_modifiers", {}),
+            duration=duration,
+            description=template["description"],
+            start_turn=self.current_turn,
+            sector_id=None,
+        )
+
+        self.active_events.append(event)
+
+        for commodity in event.affected_commodities:
+            if commodity in self.commodities:
+                price_mod = event.price_modifiers.get(commodity, 1.0)
+                self.commodities[commodity].event_modifier = price_mod
+
+                supply_mod = event.supply_modifiers.get(commodity, 1.0)
+                self.commodities[commodity].supply = int(
+                    self.commodities[commodity].supply * supply_mod
+                )
+
+                demand_mod = event.demand_modifiers.get(commodity, 1.0)
+                self.commodities[commodity].demand = int(
+                    self.commodities[commodity].demand * demand_mod
+                )
+
+        return event
     
     def _update_sector_economy(self, economy: SectorEconomy):
         """Update a sector's economic conditions"""

--- a/game/enhanced_missions.py
+++ b/game/enhanced_missions.py
@@ -599,7 +599,7 @@ class StoryMissionManager:
 
 class MissionManager:
     """Main mission management system"""
-    
+
     def __init__(self):
         self.active_missions = {}
         self.completed_missions = []
@@ -608,7 +608,24 @@ class MissionManager:
         self.mission_generator = MissionGenerator()
         self.story_manager = StoryMissionManager()
         self.turn_counter = 0
-    
+
+    def generate_event_mission(self, sector_id: int) -> Mission:
+        """Generate a mission tied to a world event.
+
+        This helper is used by the :class:`EventEngine` to quickly produce a
+        mission when a dynamic event occurs (for example, investigating an
+        anomaly or responding to pirate activity).  The mission is added to the
+        pool of available missions and returned for further processing.
+        """
+        mission = self.mission_generator.generate_mission(
+            player_level=10,
+            player_location=sector_id,
+            player_reputation={},
+        )
+        mission.sector_id = sector_id
+        self.available_missions.append(mission)
+        return mission
+
     def update_turn(self):
         """Update missions at the end of each turn"""
         self.turn_counter += 1

--- a/game/event_engine.py
+++ b/game/event_engine.py
@@ -1,0 +1,151 @@
+import random
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .dynamic_markets import DynamicMarketSystem, EconomicEvent
+from .enhanced_missions import MissionManager
+from .player import Player
+
+
+@dataclass
+class GameEvent:
+    """Simple representation of an in-game event."""
+
+    name: str
+    description: str
+    sector_id: Optional[int] = None
+    player_specific: bool = False
+    resolved: bool = False
+    data: Dict = field(default_factory=dict)
+
+
+class EventEngine:
+    """Central event management system.
+
+    The engine coordinates sector-wide and player specific events and can
+    interact with other game systems such as missions, markets and travel.
+    """
+
+    def __init__(
+        self,
+        mission_manager: Optional[MissionManager] = None,
+        market_system: Optional[DynamicMarketSystem] = None,
+        player: Optional[Player] = None,
+        travel_event_chance: float = 0.2,
+    ):
+        self.mission_manager = mission_manager
+        self.market_system = market_system
+        self.player = player
+        self.travel_event_chance = travel_event_chance
+        self.forced_travel_event_type: Optional[str] = None
+        self.active_events: List[GameEvent] = []
+
+    # ------------------------------------------------------------------
+    # Event generation helpers
+    # ------------------------------------------------------------------
+    def generate_sector_event(
+        self, sector_id: int, event_type: Optional[str] = None
+    ) -> GameEvent:
+        """Generate a sector-wide event.
+
+        Parameters
+        ----------
+        sector_id: int
+            Sector where the event occurs.
+        event_type: Optional[str]
+            Optional explicit event type (``"market"``, ``"mission"`` or
+            ``"anomaly"``).  When ``None`` a random type is selected.
+        """
+
+        if event_type is None:
+            event_type = random.choice(["market", "mission", "anomaly"])
+
+        if event_type == "market" and self.market_system:
+            self.market_system.trigger_event(EconomicEvent.PIRATE_RAIDS)
+            event = GameEvent(
+                name="Pirate Activity",
+                description="Pirate raids disrupt trade in the sector.",
+                sector_id=sector_id,
+            )
+        elif event_type == "mission" and self.mission_manager:
+            mission = self.mission_manager.generate_event_mission(sector_id)
+            event = GameEvent(
+                name="Mission Available",
+                description="A new mission opportunity arises.",
+                sector_id=sector_id,
+                data={"mission_id": mission.id},
+            )
+        else:
+            event = GameEvent(
+                name="Spatial Anomaly",
+                description="Strange readings detected in the sector.",
+                sector_id=sector_id,
+            )
+
+        self.active_events.append(event)
+        return event
+
+    def generate_player_event(self, event_type: str) -> Optional[GameEvent]:
+        """Generate an event that directly affects the player."""
+
+        if event_type == "pirate_ambush":
+            event = GameEvent(
+                name="Pirate Ambush",
+                description="Pirates attack during travel.",
+                player_specific=True,
+            )
+            if self.player:
+                self.player.health = max(0, self.player.health - 20)
+        elif event_type == "anomaly":
+            event = GameEvent(
+                name="Strange Anomaly",
+                description="A space-time anomaly is encountered.",
+                player_specific=True,
+            )
+        else:
+            return None
+
+        self.active_events.append(event)
+        return event
+
+    # ------------------------------------------------------------------
+    # Hooks
+    # ------------------------------------------------------------------
+    def handle_travel(
+        self, world, destination: str, force_event: Optional[str] = None
+    ) -> Optional[GameEvent]:
+        """Handle potential events triggered by travel.
+
+        Parameters
+        ----------
+        world: World
+            The world instance performing the travel.
+        destination: str
+            Name of the destination location.
+        force_event: Optional[str]
+            If provided, always triggers this specific event type.
+        """
+
+        if force_event is not None:
+            event_type = force_event
+        else:
+            if random.random() > self.travel_event_chance:
+                return None
+            event_type = self.forced_travel_event_type or random.choice(
+                ["pirate_ambush", "anomaly"]
+            )
+
+        if event_type in ("pirate_ambush", "anomaly"):
+            return self.generate_player_event(event_type)
+        else:
+            sector = world.locations[destination].sector
+            return self.generate_sector_event(sector, event_type)
+
+    # ------------------------------------------------------------------
+    def resolve_event(self, event: GameEvent) -> None:
+        """Mark an event as resolved and remove it from active events."""
+
+        event.resolved = True
+        if event in self.active_events:
+            self.active_events.remove(event)
+

--- a/game/world.py
+++ b/game/world.py
@@ -100,8 +100,22 @@ class PlanetSurface:
 
 class World:
     """Game world with locations and navigation - TW2002 style"""
-    
-    def __init__(self):
+
+    def __init__(self, event_engine=None):
+        """Create a new world.
+
+        Parameters
+        ----------
+        event_engine : Optional[EventEngine]
+            If provided, travel actions will notify the event engine so it can
+            generate encounters or other dynamic events.  The parameter is
+            optional to maintain backwards compatibility with existing tests
+            and demos that instantiate ``World`` without an event system.
+        """
+
+        # Event engine hook
+        self.event_engine = event_engine
+
         self.locations = {}
         self.current_location = "Earth Station"
         self.player_coordinates = (0, 0, 0)
@@ -547,10 +561,16 @@ class World:
         self.current_location = destination
         self.player_coordinates = dest_location.coordinates
         self.space_sector = dest_location.sector
-        
+
         # Discover the sector
         self.discovered_sectors.add(dest_location.sector)
-        
+
+        # Notify event engine about travel completion
+        if self.event_engine:
+            # The event engine may generate encounters or other travel-related
+            # events.  Any returned event is handled internally by the engine.
+            self.event_engine.handle_travel(self, destination)
+
         return True
 
     def get_current_sector_display(self) -> Dict:
@@ -719,6 +739,18 @@ class World:
             'faction': dest_location.faction,
             'services': dest_location.services
         }
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def can_jump_to(self, destination: str) -> bool:
+        """Determine whether a jump to the given destination is possible."""
+        if destination not in self.locations:
+            return False
+        current_loc = self.get_current_location()
+        if not current_loc:
+            return False
+        return destination in current_loc.connections
 
     def can_trade(self) -> bool:
         """Check if trading is available at current location"""

--- a/tests/test_event_engine.py
+++ b/tests/test_event_engine.py
@@ -1,0 +1,57 @@
+import unittest
+import random
+
+from game.event_engine import EventEngine
+from game.world import World
+from game.player import Player
+from game.dynamic_markets import DynamicMarketSystem
+from game.enhanced_missions import MissionManager
+
+
+class TestEventEngine(unittest.TestCase):
+    def setUp(self):
+        # Use a fixed seed so that random operations in the engine do not
+        # disturb global randomness for other tests in the suite.
+        random.seed(0)
+
+        self.market = DynamicMarketSystem()
+        self.missions = MissionManager()
+        self.player = Player("Tester")
+        self.engine = EventEngine(
+            mission_manager=self.missions,
+            market_system=self.market,
+            player=self.player,
+        )
+        self.world = World(event_engine=self.engine)
+
+    def tearDown(self):
+        # Reset random state so tests outside this module remain deterministic.
+        random.seed(0)
+
+    def test_sector_event_market(self):
+        initial_events = len(self.market.active_events)
+        event = self.engine.generate_sector_event(1, event_type="market")
+        self.assertEqual(len(self.market.active_events), initial_events + 1)
+        self.assertIn(event, self.engine.active_events)
+
+    def test_sector_event_mission(self):
+        initial_missions = len(self.missions.available_missions)
+        event = self.engine.generate_sector_event(1, event_type="mission")
+        self.assertGreater(len(self.missions.available_missions), initial_missions)
+        self.assertIn("mission_id", event.data)
+
+    def test_travel_event_trigger_and_resolution(self):
+        # Ensure travel always triggers a specific event for deterministic test
+        self.engine.travel_event_chance = 1.0
+        self.engine.forced_travel_event_type = "pirate_ambush"
+        start_health = self.player.health
+        self.world.instant_jump("Mars Colony")
+        self.assertLess(self.player.health, start_health)
+        event = self.engine.active_events[-1]
+        self.engine.resolve_event(event)
+        self.assertTrue(event.resolved)
+        self.assertNotIn(event, self.engine.active_events)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement event engine to generate sector-wide and player events with hooks into missions, markets, and travel
- Wire world travel to notify event engine and trigger encounters
- Expose market and mission methods to support event-driven updates and add tests

## Testing
- `python -m pytest tests/test_event_engine.py`
- `python -m pytest` *(fails: AssertionError in tests/test_game.py::test_player and tests/test_game.py::test_world)*

------
https://chatgpt.com/codex/tasks/task_e_689711c961b08327bf56eaa72fad5fa4