### PR TITLE
Add ship customization system with upgrade persistence

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -7,6 +7,7 @@ import random
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from game.skills import Skill
+from game.ship_customization import ShipCustomization
 
 @dataclass
 class Item:
@@ -97,6 +98,9 @@ class Player:
             'weapon_systems': 50,
             'engine_power': 100
         }
+
+        # Ship customization
+        self.ship_customization = ShipCustomization(self.ship)
         
         # Cargo holds
         self.cargo_holds = self._create_cargo_holds()
@@ -198,6 +202,15 @@ class Player:
         
         self.inventory.append(item)
         return True
+
+    # Ship upgrade interface
+    def install_upgrade(self, component_name: str) -> bool:
+        """Install a ship component upgrade."""
+        return self.ship_customization.install_component(component_name)
+
+    def remove_upgrade(self, slot: str) -> bool:
+        """Remove an installed ship component."""
+        return self.ship_customization.remove_component(slot)
     
     def remove_item(self, item_name: str, quantity: int = 1) -> Optional[Item]:
         """Remove item from inventory by name and quantity"""

--- a/game/ship_customization.py
+++ b/game/ship_customization.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class ShipComponent:
+    """Represents an upgrade component for a ship."""
+    name: str
+    slot: str
+    stats: Dict[str, int]
+
+
+@dataclass
+class ShipCustomization:
+    """Manages ship upgrade slots and installation/removal of components."""
+    ship: Dict[str, int]
+    slots: Dict[str, Optional[ShipComponent]] = field(default_factory=lambda: {
+        "engine": None,
+        "shield": None,
+        "weapon": None,
+    })
+    catalog: Dict[str, ShipComponent] = field(default_factory=lambda: {
+        "engine_mk2": ShipComponent("Engine Mk II", "engine", {"engine_power": 20}),
+        "shield_mk2": ShipComponent("Shield Mk II", "shield", {"shield_capacity": 50}),
+        "weapon_mk2": ShipComponent("Weapon Mk II", "weapon", {"weapon_systems": 30}),
+    })
+
+    def __post_init__(self) -> None:
+        # Load any existing upgrades from the ship data without re-applying stats
+        upgrades = self.ship.get("upgrades", {})
+        self.load_from_dict(upgrades, apply_stats=False)
+
+    def install_component(self, component_name: str) -> bool:
+        """Install a component into its designated slot."""
+        component = self.catalog.get(component_name)
+        if not component:
+            return False
+
+        slot = component.slot
+        if self.slots.get(slot) is not None:
+            return False
+
+        self.slots[slot] = component
+        for stat, value in component.stats.items():
+            self.ship[stat] = self.ship.get(stat, 0) + value
+        self.ship.setdefault("upgrades", {})[slot] = component.name
+        return True
+
+    def remove_component(self, slot: str) -> bool:
+        """Remove a component from the specified slot."""
+        component = self.slots.get(slot)
+        if component is None:
+            return False
+
+        for stat, value in component.stats.items():
+            self.ship[stat] = self.ship.get(stat, 0) - value
+        self.slots[slot] = None
+        if "upgrades" in self.ship:
+            self.ship["upgrades"].pop(slot, None)
+        return True
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Return a dictionary representation of installed upgrades."""
+        return {slot: comp.name if comp else None for slot, comp in self.slots.items()}
+
+    def load_from_dict(self, upgrades: Dict[str, Optional[str]], apply_stats: bool = True) -> None:
+        """Load upgrades from a dictionary representation."""
+        for slot, name in upgrades.items():
+            component = None
+            if name:
+                component = next((c for c in self.catalog.values() if c.name == name), None)
+            self.slots[slot] = component
+            if component and apply_stats:
+                for stat, value in component.stats.items():
+                    self.ship[stat] = self.ship.get(stat, 0) + value
+        if upgrades:
+            self.ship["upgrades"] = {slot: name for slot, name in upgrades.items() if name}

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from game.stock_market import StockMarket, BankingSystem
 from game.sos_system import SOSSystem
 from game.skills import Skill
 from game.ai_counselor import ShipCounselor
+from game.ship_customization import ShipCustomization
 from utils.display import DisplayManager
 from utils.input_handler import InputHandler
 from game.save_system import SaveGameSystem
@@ -169,6 +170,8 @@ class Game:
         
         [bold yellow]Ship & Equipment:[/bold yellow]
         - ship (show ship status)
+        - ship install [component] (install upgrade)
+        - ship remove [slot] (remove upgrade)
         - cargo (show cargo holds)
         - equip [item] (equip item)
         - unequip [slot] (unequip item)
@@ -197,6 +200,7 @@ class Game:
 map - Show map   jump - Sector jumping   market - Trading
 talk - NPCs      holodeck - Entertainment sos - Rescue missions
 stocks - Market  bank - Banking          ship - Ship status
+ship install/remove - Manage upgrades
 cargo - Cargo    skills - Skills         counselor - AI chat
 sectors - All sectors  sector - Current sector
         """
@@ -204,6 +208,7 @@ sectors - All sectors  sector - Current sector
 
     def _create_game_state(self):
         """Collect current game objects into a GameState"""
+        self.player.ship["upgrades"] = self.player.ship_customization.to_dict()
         return self.save_system.create_game_state(
             self.player,
             self.world,
@@ -223,10 +228,12 @@ sectors - All sectors  sector - Current sector
 
         pd = game_state.player_data
         self.player.name = pd.get("name", self.player.name)
-        self.player.ship_name = pd.get("ship_name", self.player.ship_name)
+        self.player.ship = pd.get("ship", self.player.ship)
+        self.player.ship_name = self.player.ship.get("name", self.player.ship_name)
         self.player.level = pd.get("level", self.player.level)
         self.player.credits = pd.get("credits", self.player.credits)
         self.player.experience = pd.get("experience", self.player.experience)
+        self.player.ship_customization = ShipCustomization(self.player.ship)
 
         wd = game_state.world_data
         self.world.current_sector = wd.get("current_sector", self.world.current_sector)
@@ -410,6 +417,10 @@ sectors - All sectors  sector - Current sector
                 elif command.lower().startswith('rescue'):
                     self.handle_rescue(command)
                 
+                elif command.lower().startswith('ship install'):
+                    self.handle_ship_install(command)
+                elif command.lower().startswith('ship remove'):
+                    self.handle_ship_remove(command)
                 elif command.lower() == 'ship':
                     self.show_ship_status()
                 
@@ -890,6 +901,37 @@ sectors - All sectors  sector - Current sector
         self.console.print(f"Shield Capacity: {ship['shield_capacity']}")
         self.console.print(f"Weapon Systems: {ship['weapon_systems']}")
         self.console.print(f"Engine Power: {ship['engine_power']}")
+        upgrades = ship.get('upgrades', {})
+        if upgrades:
+            self.console.print("Upgrades:")
+            for slot, name in upgrades.items():
+                self.console.print(f"  {slot}: {name}")
+        else:
+            self.console.print("No upgrades installed.")
+
+    def handle_ship_install(self, command):
+        """Install a ship upgrade component."""
+        parts = command.split()
+        if len(parts) < 3:
+            self.console.print("[red]Usage: ship install [component][/red]")
+            return
+        component = parts[2]
+        if self.player.install_upgrade(component):
+            self.console.print(f"[green]{component} installed.[/green]")
+        else:
+            self.console.print(f"[red]Failed to install {component}.[/red]")
+
+    def handle_ship_remove(self, command):
+        """Remove an installed ship upgrade."""
+        parts = command.split()
+        if len(parts) < 3:
+            self.console.print("[red]Usage: ship remove [slot][/red]")
+            return
+        slot = parts[2]
+        if self.player.remove_upgrade(slot):
+            self.console.print(f"[green]{slot} upgrade removed.[/green]")
+        else:
+            self.console.print(f"[red]No upgrade installed in {slot} slot.[/red]")
 
     def show_cargo(self):
         """Show cargo holds"""

--- a/tests/test_ship_customization.py
+++ b/tests/test_ship_customization.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from game.player import Player
+
+
+def test_install_and_remove_upgrade():
+    player = Player()
+    base_engine = player.ship['engine_power']
+
+    assert player.install_upgrade('engine_mk2')
+    assert player.ship['engine_power'] == base_engine + 20
+    assert player.ship['upgrades']['engine'] == 'Engine Mk II'
+
+    # Cannot install again in same slot
+    assert not player.install_upgrade('engine_mk2')
+
+    assert player.remove_upgrade('engine')
+    assert player.ship['engine_power'] == base_engine
+    assert 'engine' not in player.ship.get('upgrades', {})
+
+
+def test_persist_upgrades():
+    player = Player()
+    base_shield = player.ship['shield_capacity']
+    player.install_upgrade('shield_mk2')
+
+    saved_upgrades = player.ship_customization.to_dict()
+    new_player = Player()
+    new_player.ship_customization.load_from_dict(saved_upgrades, apply_stats=True)
+
+    assert new_player.ship['shield_capacity'] == base_shield + 50
+    assert new_player.ship['upgrades']['shield'] == 'Shield Mk II'


### PR DESCRIPTION
## Summary
- Add ship_customization module with upgrade slots and install/remove logic
- Wire ship commands to install and remove upgrades and save them
- Test installing, removing, and persisting ship upgrades

## Testing
- `pytest`
- `pytest tests/test_ship_customization.py`


------
https://chatgpt.com/codex/tasks/task_e_689711c812408327891dead9974bff42