### PR TITLE
fix: adjust starting inventory item count

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -135,8 +135,7 @@ class Player:
             Item("Med Kit", "Basic medical supplies", 25, "consumable"),
             Item("Energy Shield", "Personal protective field", 40, "shield", defense=5),
             Item("Repair Tool", "Basic repair equipment", 20, "equipment"),
-            Item("Navigation Computer", "Advanced navigation system", 60, "equipment"),
-            Item("Genesis Torpedo", "A device capable of creating a new planet.", 1000, "special")
+            Item("Navigation Computer", "Advanced navigation system", 60, "equipment")
         ]
         
         for item in starting_items:


### PR DESCRIPTION
## Summary
- remove Genesis Torpedo from player's starting inventory so the game begins with six basic items

## Testing
- `PYTHONPATH=. pytest tests/test_game.py::test_player -q`
- `PYTHONPATH=. pytest -q` *(fails: AttributeError: 'World' object has no attribute 'can_jump_to' in tests/test_game.py::test_world)*

------
https://chatgpt.com/codex/tasks/task_e_6897104bcdc083278c7e24fd72bc0243