### PR TITLE
Add Player skill lookup helper

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -190,6 +190,13 @@ class Player:
         # Gain skill points
         for skill in self.skills.values():
             skill.gain_experience(random.randint(5, 15))
+
+    def get_skill_level(self, skill_name: str) -> int:
+        """Get the level of a skill, returning 0 if unknown."""
+        skill = self.skills.get(skill_name.lower())
+        if skill:
+            return skill.level
+        return 0
     
     def add_item(self, item: Item) -> bool:
         """Add item to inventory"""


### PR DESCRIPTION
## Summary
- add `Player.get_skill_level` to safely retrieve skill levels
- ensures missing skills return 0

## Testing
- `PYTHONPATH=. pytest -q` (fails: expected 6 starting items and World.can_jump_to missing)

------
https://chatgpt.com/codex/tasks/task_e_68971046e0c88327b1de5709a15328d7