### PR TITLE
Stack trade goods when buying

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -192,10 +192,25 @@ class Player:
             skill.gain_experience(random.randint(5, 15))
     
     def add_item(self, item: Item) -> bool:
-        """Add item to inventory"""
+        """Add item to inventory.
+
+        Trade goods with the same name stack using the quantity attribute
+        rather than occupying multiple inventory slots.
+        """
+        # First try to stack trade goods
+        if item.item_type == 'trade_good':
+            for inv_item in self.inventory:
+                if (
+                    inv_item.item_type == 'trade_good'
+                    and inv_item.name.lower() == item.name.lower()
+                ):
+                    inv_item.quantity += item.quantity
+                    return True
+
+        # No existing stack found; check inventory capacity
         if len(self.inventory) >= self.max_inventory:
             return False
-        
+
         self.inventory.append(item)
         return True
     

--- a/game/trading.py
+++ b/game/trading.py
@@ -213,18 +213,19 @@ class TradingSystem:
         if player.credits < total_cost:
             return {'success': False, 'message': f'Not enough credits. Need {total_cost}, have {player.credits}'}
         
-        # Create the item and add to inventory
+        # Create the item and add to inventory. The player's add_item method
+        # will handle stacking identical trade goods by quantity.
         item = Item(
             name=item_data['name'],
             description=item_data['description'],
             value=item_data['price'],
-            item_type='trade_good'
+            item_type='trade_good',
+            quantity=quantity
         )
-        
-        # Add items to inventory
-        for _ in range(quantity):
-            if not player.add_item(item):
-                return {'success': False, 'message': 'Inventory full'}
+
+        # Add item (or stack) to inventory
+        if not player.add_item(item):
+            return {'success': False, 'message': 'Inventory full'}
         
         # Deduct credits
         player.spend_credits(total_cost)

--- a/tests/test_trading_stack.py
+++ b/tests/test_trading_stack.py
@@ -1,0 +1,46 @@
+"""Tests for trading and item stacking mechanics."""
+
+import random
+
+from game.player import Player, Item
+from game.trading import TradingSystem
+
+
+def test_player_add_item_stacks_trade_goods():
+    """Identical trade goods should stack via quantity."""
+    player = Player()
+
+    gold1 = Item("Gold", "Precious metal", 100, "trade_good")
+    gold2 = Item("Gold", "Precious metal", 100, "trade_good")
+
+    assert player.add_item(gold1)
+    assert player.add_item(gold2)
+
+    item = player.get_item("Gold")
+    assert item is not None
+    assert item.quantity == 2
+    # Only one inventory slot should be used for both items
+    assert len([i for i in player.inventory if i.name == "Gold"]) == 1
+
+
+def test_buy_item_stacks_in_inventory():
+    """Buying multiple units should stack rather than duplicate entries."""
+    random.seed(0)
+    player = Player()
+    trading = TradingSystem()
+
+    # Purchase two Energy Cells
+    result = trading.buy_item(player, "Earth Station", "Energy Cells", quantity=2)
+    assert result["success"]
+    item = player.get_item("Energy Cells")
+    assert item is not None
+    assert item.quantity == 2
+    inventory_count = len(player.inventory)
+
+    # Purchase three more; quantity should increase but inventory count stay the same
+    result = trading.buy_item(player, "Earth Station", "Energy Cells", quantity=3)
+    assert result["success"]
+    item = player.get_item("Energy Cells")
+    assert item.quantity == 5
+    assert len(player.inventory) == inventory_count
+


### PR DESCRIPTION
## Summary
- Stack identical trade goods in the player's inventory via quantity field
- Ensure TradingSystem.buy_item creates items with quantity instead of reusing references
- Add tests covering trade good stacking

## Testing
- `PYTHONPATH=. pytest tests/test_trading_stack.py`
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'World' object has no attribute 'can_jump_to'; AssertionError: assert 7 == 6)*

------
https://chatgpt.com/codex/tasks/task_e_689710490a8c832782e52c94abb5184c