### PR TITLE
Add skill level accessor and update skill lookups

### DIFF
--- a/game/enhanced_combat.py
+++ b/game/enhanced_combat.py
@@ -742,7 +742,10 @@ class EnhancedCombatSystem:
                 energy_cost=0
             )
         ]
-        
+
+        piloting_skill = player.get_skill_level("piloting")
+        leadership_skill = player.get_skill_level("leadership")
+
         return CombatShip(
             name=player.ship_name,
             hull=player.health,
@@ -753,8 +756,8 @@ class EnhancedCombatSystem:
             max_energy=player.max_energy,
             weapons=weapons,
             defenses=defenses,
-            agility=5 + player.get_skill_level("piloting"),
-            crew=player.get_skill_level("leadership") * 10 + 50,
+            agility=5 + piloting_skill,
+            crew=leadership_skill * 10 + 50,
             max_crew=100,
             special_abilities=[]
         )

--- a/game/player.py
+++ b/game/player.py
@@ -190,7 +190,19 @@ class Player:
         # Gain skill points
         for skill in self.skills.values():
             skill.gain_experience(random.randint(5, 15))
-    
+
+    def get_skill_level(self, skill_name: str) -> int:
+        """Retrieve the player's level in a given skill.
+
+        Args:
+            skill_name: Name of the skill to look up.
+
+        Returns:
+            The level of the skill if the player possesses it, otherwise 0.
+        """
+        skill = self.skills.get(skill_name.lower())
+        return skill.level if skill else 0
+
     def add_item(self, item: Item) -> bool:
         """Add item to inventory"""
         if len(self.inventory) >= self.max_inventory:

--- a/game/quests.py
+++ b/game/quests.py
@@ -163,7 +163,7 @@ class QuestSystem:
                 if player.credits < req_value:
                     return False
             elif req_type.endswith('_skill'):
-                skill_name = req_type.replace('_skill', '')
+                skill_name = req_type.replace('_skill', '').lower()
                 if player.get_skill_level(skill_name) < req_value:
                     return False
         


### PR DESCRIPTION
## Summary
- add `Player.get_skill_level` for safe skill lookups
- use `get_skill_level` in quest requirements and combat ship creation

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'game')

------
https://chatgpt.com/codex/tasks/task_e_6897103bfc788327bfbc8b562dcb6a8b