### PR TITLE
Enable quests and market changes from NPC dialogue

### DIFF
--- a/game/trading.py
+++ b/game/trading.py
@@ -165,6 +165,12 @@ class TradingSystem:
         """Update prices for all markets"""
         for location, market_data in self.location_markets.items():
             self._update_market_prices(location, market_data)
+
+    def apply_price_modifier(self, location: str, modifier: float):
+        """Apply a temporary price modifier to a market"""
+        if location in self.location_markets:
+            self.location_markets[location]['price_modifier'] *= modifier
+            self._update_market_prices(location, self.location_markets[location])
     
     def get_market_info(self, location: str) -> Dict:
         """Get market information for a location"""

--- a/main.py
+++ b/main.py
@@ -215,7 +215,7 @@ sectors - All sectors  sector - Current sector
         self.combat_system = CombatSystem()
         self.trading_system = TradingSystem()
         self.quest_system = QuestSystem()
-        self.npc_system = NPCSystem()
+        self.npc_system = NPCSystem(self.quest_system, self.trading_system)
         self.holodeck_system = HolodeckSystem()
         self.stock_market = StockMarket()
         self.banking_system = BankingSystem()
@@ -709,7 +709,20 @@ sectors - All sectors  sector - Current sector
                 
                 result = self.npc_system.handle_conversation_choice(self.player, npc, selected_option)
                 self.console.print(f"[cyan]{result['message']}[/cyan]")
-                
+
+                if result.get('quest_offer'):
+                    quest_id = result['quest_offer']
+                    quest = self.quest_system.available_quests.get(quest_id)
+                    if quest and Confirm.ask(f"Accept quest '{quest.name}'?"):
+                        q_result = self.quest_system.accept_quest(self.player, quest_id)
+                        self.console.print(f"[green]{q_result['message']}[/green]")
+
+                if result.get('price_modifier'):
+                    self.console.print(f"[green]Market prices adjusted at {npc.location}![/green]")
+
+                if result.get('rep_change'):
+                    self.console.print(f"[magenta]Relationship with {npc.name} changed by {result['rep_change']}[/magenta]")
+
                 if result.get('end_conversation'):
                     break
                     


### PR DESCRIPTION
## Summary
- Link NPCs with quest and trading systems
- Offer quests or market price shifts when discussing rumors
- Track relationship changes from conversation outcomes

## Testing
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'World' object has no attribute 'can_jump_to')*

------
https://chatgpt.com/codex/tasks/task_e_68971032ad088327953b2d03bde7784e