### PR TITLE
Add experience wrapper and skill level helper

### DIFF
--- a/game/combat.py
+++ b/game/combat.py
@@ -295,7 +295,7 @@ class CombatSystem:
         if not self.current_enemy or not self.player:
             return
         
-        # Give experience
+        # Give experience using player.add_experience wrapper
         exp_gained = self.current_enemy.experience_reward
         leveled_up = self.player.add_experience(exp_gained)
         

--- a/game/player.py
+++ b/game/player.py
@@ -160,10 +160,16 @@ class Player:
     def gain_experience(self, amount: int):
         """Gain experience points"""
         self.experience += amount
-        
+
         # Check for level up
         while self.experience >= self.experience_to_next:
             self.level_up()
+
+    def add_experience(self, amount: int) -> bool:
+        """Add experience and return True if a level up occurred."""
+        previous_level = self.level
+        self.gain_experience(amount)
+        return self.level > previous_level
     
     def level_up(self):
         """Level up the player"""
@@ -190,6 +196,11 @@ class Player:
         # Gain skill points
         for skill in self.skills.values():
             skill.gain_experience(random.randint(5, 15))
+
+    def get_skill_level(self, skill_name: str) -> int:
+        """Get the level of the specified skill, or 0 if not found."""
+        skill = self.skills.get(skill_name)
+        return skill.level if skill else 0
     
     def add_item(self, item: Item) -> bool:
         """Add item to inventory"""

--- a/game/quests.py
+++ b/game/quests.py
@@ -164,6 +164,7 @@ class QuestSystem:
                     return False
             elif req_type.endswith('_skill'):
                 skill_name = req_type.replace('_skill', '')
+                # Use player's get_skill_level accessor
                 if player.get_skill_level(skill_name) < req_value:
                     return False
         
@@ -231,7 +232,7 @@ class QuestSystem:
         """Give quest rewards to player"""
         rewards_given = {}
         
-        # Experience
+        # Experience using player.add_experience wrapper
         if 'experience' in quest.rewards:
             exp_gained = quest.rewards['experience']
             leveled_up = player.add_experience(exp_gained)


### PR DESCRIPTION
## Summary
- Add Player.add_experience wrapper that reports level ups
- Expose Player.get_skill_level with safe defaults
- Update combat and quest reward/requirement handling to use new helper methods

## Testing
- `python - <<'PY'
from game.player import Player
p=Player()
print('initial level', p.level)
leveled = p.add_experience(150)
print('leveled', leveled)
print('new level', p.level, 'remaining exp', p.experience)
print('combat skill level', p.get_skill_level('combat'))
print('unknown skill level', p.get_skill_level('unknown'))
PY`
- `PYTHONPATH=$PWD pytest tests/test_game.py::test_quests -q`

------
https://chatgpt.com/codex/tasks/task_e_68971007bdd08327a6a8954d5f18f363